### PR TITLE
Batch create mutation

### DIFF
--- a/strawberry_django/resolvers.py
+++ b/strawberry_django/resolvers.py
@@ -157,7 +157,7 @@ class ModelQueryMixin:
     def mutation(cls):
         object_name = utils.camel_to_snake(cls.model._meta.object_name)
         class Mutation: pass
-        setattr(Mutation, f'create_{object_name}', cls.create_mutation())
+        setattr(Mutation, f'create_{object_name}s', cls.create_mutation())
         setattr(Mutation, f'update_{object_name}s', cls.update_mutation())
         setattr(Mutation, f'delete_{object_name}s', cls.delete_mutation())
         return strawberry.type(Mutation)

--- a/strawberry_django/resolvers.py
+++ b/strawberry_django/resolvers.py
@@ -1,9 +1,11 @@
-from typing import List, Optional, cast
+from typing import List, Optional
+
 import strawberry
+from django.db import transaction
+
 from . import utils
-from .types import generate_model_type
 from .permissions import permission_class_wrapper
-from django.core import exceptions
+from .types import generate_model_type
 
 
 class ModelResolverMixin:
@@ -52,12 +54,9 @@ class ModelResolverMixin:
         instance.save()
         return instance
 
+    @transaction.atomic
     def batch_create(self, data):
-        model = self.get_model()
-        instances = [model(**i) for i in data]
-        for instance in instances:
-            instance.save()
-        return instances
+        return [self.create(i) for i in data]
 
     def update(self, data, **filters):
         qs = self.get_queryset_filtered(**filters)

--- a/strawberry_django/resolvers.py
+++ b/strawberry_django/resolvers.py
@@ -48,9 +48,10 @@ class ModelResolverMixin:
 
     def create(self, data):
         model = self.get_model()
-        instance = model(**data)
-        instance.save()
-        return instance
+        instances = [model(**i) for i in data]
+        for instance in instances:
+            instance.save()
+        return instances
 
     def update(self, data, **filters):
         qs = self.get_queryset_filtered(**filters)
@@ -109,9 +110,9 @@ class ModelMutationMixin:
         permission_classes = get_permission_classes(cls, 'add')
 
         @strawberry.mutation(permission_classes=permission_classes)
-        def create_mutation(info, root, data: cls.create_input_type) -> cls.output_type:
+        def create_mutation(info, root, data: List[cls.create_input_type]) -> List[cls.output_type]:
             instance = cls(info, root)
-            return instance.create(utils.get_data(cls.model, data))
+            return instance.create([utils.get_data(cls.model, i) for i in data])
         return create_mutation
 
     @classmethod

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -27,15 +27,42 @@ def schema(testdata):
 
 
 def test_mutation_create(schema):
-    result = schema.execute_sync('mutation { user: createUser(data: {name: "x", age: 1}) { id name age } }')
+    result = schema.execute_sync('mutation { user: createUsers(data: {name: "x", age: 1}) { id name age } }')
 
     assert not result.errors
-    assert result.data['user']['name'] == 'x'
-    assert result.data['user']['age'] == 1
+    assert result.data['user'][0]['name'] == 'x'
+    assert result.data['user'][0]['age'] == 1
 
-    user = User.objects.get(id=result.data['user']['id'])
+    user = User.objects.get(id=result.data['user'][0]['id'])
     assert user.name == 'x'
     assert user.age == 1
+
+
+def test_batch_mutation_create(schema):
+    result = schema.execute_sync('''
+    mutation {
+        user: createUsers(data: [
+            {name: "d", age: 1},
+            {name: "e", age: 2}
+        ]) {
+            id
+            name
+            age
+        }
+    }''')
+
+    assert not result.errors
+    assert result.data['user'][0]['name'] == 'd'
+    assert result.data['user'][0]['age'] == 1
+    assert result.data['user'][1]['name'] == 'e'
+    assert result.data['user'][1]['age'] == 2
+
+    user = User.objects.get(id=result.data['user'][0]['id'])
+    assert user.name == 'd'
+    assert user.age == 1
+    user = User.objects.get(id=result.data['user'][1]['id'])
+    assert user.name == 'e'
+    assert user.age == 2
 
 
 def test_mutation_update(schema):
@@ -61,10 +88,10 @@ def test_mutation_delete(schema):
 
 
 def test_mutation_create_with_relation(schema):
-    result = schema.execute_sync('mutation { group: createGroup(data: {name: "x", admin: 3}) { admin { name }} }')
+    result = schema.execute_sync('mutation { group: createGroups(data: {name: "x", admin: 3}) { admin { name }} }')
 
     assert not result.errors
-    assert result.data['group']['admin']['name'] == 'c'
+    assert result.data['group'][0]['admin']['name'] == 'c'
 
 
 def test_mutation_update_relation(schema):

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -27,18 +27,18 @@ def schema(testdata):
 
 
 def test_mutation_create(schema):
-    result = schema.execute_sync('mutation { user: createUsers(data: {name: "x", age: 1}) { id name age } }')
+    result = schema.execute_sync('mutation { user: createUser(data: {name: "x", age: 1}) { id name age } }')
 
     assert not result.errors
-    assert result.data['user'][0]['name'] == 'x'
-    assert result.data['user'][0]['age'] == 1
+    assert result.data['user']['name'] == 'x'
+    assert result.data['user']['age'] == 1
 
-    user = User.objects.get(id=result.data['user'][0]['id'])
+    user = User.objects.get(id=result.data['user']['id'])
     assert user.name == 'x'
     assert user.age == 1
 
 
-def test_batch_mutation_create(schema):
+def test_batch_create_mutation(schema):
     result = schema.execute_sync('''
     mutation {
         user: createUsers(data: [
@@ -88,10 +88,10 @@ def test_mutation_delete(schema):
 
 
 def test_mutation_create_with_relation(schema):
-    result = schema.execute_sync('mutation { group: createGroups(data: {name: "x", admin: 3}) { admin { name }} }')
+    result = schema.execute_sync('mutation { group: createGroup(data: {name: "x", admin: 3}) { admin { name }} }')
 
     assert not result.errors
-    assert result.data['group'][0]['admin']['name'] == 'c'
+    assert result.data['group']['admin']['name'] == 'c'
 
 
 def test_mutation_update_relation(schema):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -54,7 +54,7 @@ def test_query_without_permissions(schema, context):
 
 def test_mutation_without_permissions(schema, context):
     result = schema.execute_sync(context_value=context,
-            query='mutation { createUser(data: {name: "hello", age: 1}) { id } }')
+            query='mutation { createUsers(data: {name: "hello", age: 1}) { id } }')
     assert result.errors[0].message == 'User does not have app.add_user permission'
 
     result = schema.execute_sync(context_value=context,
@@ -82,7 +82,7 @@ def test_add_permissions(schema, context):
     context['permissions'] = ['app.add_user']
 
     result = schema.execute_sync(context_value=context,
-            query='mutation { createUser(data: {name: "hello", age: 1}) { id } }')
+            query='mutation { createUsers(data: {name: "hello", age: 1}) { id } }')
     assert not result.errors
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -54,7 +54,7 @@ def test_query_without_permissions(schema, context):
 
 def test_mutation_without_permissions(schema, context):
     result = schema.execute_sync(context_value=context,
-            query='mutation { createUsers(data: {name: "hello", age: 1}) { id } }')
+            query='mutation { createUser(data: {name: "hello", age: 1}) { id } }')
     assert result.errors[0].message == 'User does not have app.add_user permission'
 
     result = schema.execute_sync(context_value=context,
@@ -82,7 +82,7 @@ def test_add_permissions(schema, context):
     context['permissions'] = ['app.add_user']
 
     result = schema.execute_sync(context_value=context,
-            query='mutation { createUsers(data: {name: "hello", age: 1}) { id } }')
+            query='mutation { createUser(data: {name: "hello", age: 1}) { id } }')
     assert not result.errors
 
 


### PR DESCRIPTION
can do
```graphql
mutation {
  createItems(data: [{name: "item1"}, {name: "item2"}]) {
    id
  }
}
```
Keep the `createItem` at the same time.